### PR TITLE
Add config back in for markdown checker

### DIFF
--- a/.mlc-config.json
+++ b/.mlc-config.json
@@ -1,0 +1,27 @@
+{
+    "_comment": "Markdown Link Checker configuration, see https://github.com/gaurav-nelson/github-action-markdown-link-check and https://github.com/tcort/markdown-link-check",
+    "ignorePatterns": [
+        {
+            "pattern": "^http://localhost"
+        },
+        {
+            "pattern": "\\{\\{"
+        },
+        {
+          "pattern": "^https://doi.org/<replace-with-created-DOI>"
+        },
+        {
+          "pattern": "^https://bestpractices.coreinfrastructure.org/projects/<replace-with-created-project-identifier>"
+        },
+        {
+          "pattern": "^.github/workflows/sonarcloud.yml$"
+        },
+        {
+          "pattern": "^https://readthedocs.org/dashboard/import.*"
+        }
+    ],
+    "replacementPatterns": [
+    ],
+    "retryOn429": true,
+    "timeout": "20s"
+}


### PR DESCRIPTION
This config file is needed for the markdown checker to work