### PR TITLE
Split documentation workflows into test and deploy

### DIFF
--- a/.github/workflows/documentation-deploy.yml
+++ b/.github/workflows/documentation-deploy.yml
@@ -1,4 +1,4 @@
-name: documentation
+name: documentation-deploy
 
 permissions: write-all
 

--- a/.github/workflows/documentation-deploy.yml
+++ b/.github/workflows/documentation-deploy.yml
@@ -2,36 +2,11 @@ name: documentation
 
 permissions: write-all
 
-
 on:
-  push:
-    branches:
-    - main
-  pull_request:
-    branches:
-    - main
+  release:
+    types: [created]
 
 jobs:
-  build-docs:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.9
-
-      - name: Install dependencies
-        run: |
-          pip install ".[doc]" 
-      - name: Deploy mkdocs on GitHub Pages
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          mkdocs build
-
   build-docs-and-deploy:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')  # only deploy docs on tag release

--- a/.github/workflows/documentation-deploy.yml
+++ b/.github/workflows/documentation-deploy.yml
@@ -10,8 +10,6 @@ jobs:
   build-docs-and-deploy:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')  # only deploy docs on tag release
-    needs:
-    - build-docs
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/documentation-test.yml
+++ b/.github/workflows/documentation-test.yml
@@ -1,4 +1,4 @@
-name: documentation
+name: documentation-test
 
 on:
   push:

--- a/.github/workflows/documentation-test.yml
+++ b/.github/workflows/documentation-test.yml
@@ -1,0 +1,30 @@
+name: documentation
+
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+
+      - name: Install dependencies
+        run: |
+          pip install ".[doc]" 
+      - name: Test mkdocs build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdocs build

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -26,7 +26,7 @@ authors:
 
 date-released: 2024-03-26
 doi: 10.5281/zenodo.10877886
-version: "0.2.1"
+version: "0.2.2"
 repository-code: "https://github.com/MiBiPreT/anatrans"
 keywords:
   - groundwater

--- a/anatrans/__init__.py
+++ b/anatrans/__init__.py
@@ -5,4 +5,4 @@ logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 __author__ = "Alraune Zech"
 __email__ = "a.zech@uu.nl"
-__version__ = "0.2.1"
+__version__ = "0.2.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ license = {file = "LICENSE"}
 name = "anatrans"
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.8"
-version = "0.2.1"
+version = "0.2.2"
 
 [project.optional-dependencies]
 dev = [
@@ -198,7 +198,7 @@ force-single-line = true
 no-lines-before = ["future","standard-library","third-party","first-party","local-folder"]
 
 [tool.bumpversion]
-current_version = "0.2.1"
+current_version = "0.2.2"
 
 [[tool.bumpversion.files]]
 filename = "anatrans/__init__.py"


### PR DESCRIPTION
To simplify the workflow triggers, this splits the documentation test build and the documentation deploy into two separate workflows.